### PR TITLE
Fixing `get_arch` for Apple Silicon

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -70,7 +70,19 @@ install_version() {
 }
 
 get_arch() {
-  uname -m
+  local arch
+  arch=$(uname -m)
+  case $arch in
+  "x86_64")
+    echo "x86_64"
+    ;;
+  "arm64")
+    echo "aarch64"
+    ;;
+  *)
+    exit 1
+    ;;
+  esac
 }
 
 get_platform() {


### PR DESCRIPTION
The ARM binaries use `aarch64` instead of `arm64` in their names:
https://github.com/zellij-org/zellij/releases/tag/v0.35.2