### PR TITLE
Return proper architecture on arm64 linux

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -76,7 +76,7 @@ get_arch() {
   "x86_64")
     echo "x86_64"
     ;;
-  "arm64")
+  "arm64" | "aarch64")
     echo "aarch64"
     ;;
   *)


### PR DESCRIPTION
ubuntu (and debian, also possible other linuxes) return `aarch64` when running `uname -m`